### PR TITLE
Add missing `termType` and `value` to `Quad`

### DIFF
--- a/src/core/data/factory.js.jmacs
+++ b/src/core/data/factory.js.jmacs
@@ -1132,6 +1132,8 @@ function Quad(h_subject, h_predicate, h_object, h_graph=KT_DEFAULT_GRAPH) {
 	this.object = h_object;
 	this.graph = h_graph;
 } Object.assign(Quad.prototype, {
+	value: '',
+	termType: 'Quad',
 	isGraphyQuad: true,
 
 	equals(z_other) {


### PR DESCRIPTION
A `Quad` must have a `termType` and `value`, since it's a `Term`: https://rdf.js.org/data-model-spec/#quad-interface

A recent change to Comunica (not sure what) appears to care now, and blows up if the `Quad`s don't have `termType` available. This should fix that.